### PR TITLE
Implement gameplay modules

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -47,3 +47,77 @@ body {
   padding: 8px 16px;
   font-weight: 600;
 }
+
+/* Cenário de jogo com imagem de fundo */
+.scene {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 160px);
+  background-size: cover;
+  background-position: center;
+}
+
+/* Pontos clicáveis */
+.hotspot {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  background-color: rgba(241, 196, 15, 0.8);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* Modal de pergunta */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.modal-content {
+  background-color: #2c2c2c;
+  color: #ffffff;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  width: 80%;
+  max-width: 320px;
+}
+
+.modal-content h2 {
+  margin-top: 0;
+  font-weight: 600;
+}
+
+.modal-content .options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.modal-content .options button {
+  background-color: #f1c40f;
+  color: #2c2c2c;
+  border: none;
+  border-radius: 8px;
+  padding: 8px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* Tela final de vitória ou derrota */
+.end-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 160px);
+  gap: 16px;
+}

--- a/app/src/components/QuestionModal.js
+++ b/app/src/components/QuestionModal.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import '../App.css';
+
+export default function QuestionModal({ visible, question, onClose }) {
+  if (!question) return null;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="modal-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="modal-content"
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            exit={{ scale: 0.8 }}
+          >
+            <h2>{question.prompt}</h2>
+            <div className="options">
+              {question.options.map((opt, idx) => (
+                <button key={idx} onClick={() => onClose(idx === question.answer)}>
+                  {opt}
+                </button>
+              ))}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { GameProvider } from './context/GameContext';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
@@ -9,7 +10,9 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <GameProvider>
+        <App />
+      </GameProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/app/src/pages/Module1.js
+++ b/app/src/pages/Module1.js
@@ -1,5 +1,107 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGame } from '../context/GameContext';
+import QuestionModal from '../components/QuestionModal';
+import { motion } from 'framer-motion';
+import '../App.css';
 
 export default function Module1() {
-  return <div>Modulo 1</div>;
+  // Perguntas do módulo com posições dos hotspots
+  const questions = [
+    {
+      id: 'q1',
+      x: '30%',
+      y: '40%',
+      prompt: 'Que fração da pizza está faltando?',
+      options: ['1/4', '1/2', '3/4', '1/8'],
+      answer: 0,
+    },
+    {
+      id: 'q2',
+      x: '60%',
+      y: '50%',
+      prompt: 'Quanto é 2/3 + 3/4?',
+      options: ['6/7', '17/12', '1', '5/12'],
+      answer: 1,
+    },
+    {
+      id: 'q3',
+      x: '80%',
+      y: '70%',
+      prompt: '3/4 equivale a quantos porcento?',
+      options: ['50%', '75%', '25%', '100%'],
+      answer: 1,
+    },
+  ];
+
+  const [currentQ, setCurrentQ] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+  const [finished, setFinished] = useState(false);
+  const { lives, addXp, loseLife, resetGame, completeMod } = useGame();
+  const navigate = useNavigate();
+
+  // Trata fechamento do modal e avança lógica do jogo
+  const handleClose = (correct) => {
+    setShowModal(false);
+    if (correct) {
+      addXp(10);
+    } else {
+      loseLife();
+    }
+    if (!correct && lives - 1 <= 0) return; // derrota acontecerá
+    if (currentQ + 1 < questions.length) {
+      setCurrentQ(currentQ + 1);
+    } else {
+      completeMod(1);
+      setFinished(true);
+    }
+  };
+
+  // Tela de derrota
+  if (lives <= 0) {
+    return (
+      <div className="end-screen">
+        <h2>Game Over</h2>
+        <button onClick={resetGame}>Reiniciar</button>
+      </div>
+    );
+  }
+
+  // Tela de vitória
+  if (finished) {
+    return (
+      <div className="end-screen">
+        <h2>Missão Completa!</h2>
+        <button onClick={() => navigate('/modulo2')}>Próxima Missão</button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="scene"
+      style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/padaria.png)` }}
+    >
+      {/* Hotspots que disparam as perguntas */}
+      {questions.map((q, i) => (
+        <motion.div
+          key={q.id}
+          className="hotspot"
+          style={{ left: q.x, top: q.y }}
+          onClick={() => {
+            setCurrentQ(i);
+            setShowModal(true);
+          }}
+          whileHover={{ scale: 1.2 }}
+        />
+      ))}
+
+      {/* Modal de pergunta e validação */}
+      <QuestionModal
+        visible={showModal}
+        question={questions[currentQ]}
+        onClose={handleClose}
+      />
+    </div>
+  );
 }

--- a/app/src/pages/Module2.js
+++ b/app/src/pages/Module2.js
@@ -1,5 +1,101 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGame } from '../context/GameContext';
+import QuestionModal from '../components/QuestionModal';
+import { motion } from 'framer-motion';
+import '../App.css';
 
 export default function Module2() {
-  return <div>Modulo 2</div>;
+  const questions = [
+    {
+      id: 'q1',
+      x: '35%',
+      y: '45%',
+      prompt: 'Qual bioma possui clima quente e úmido o ano todo?',
+      options: ['Floresta Tropical', 'Deserto', 'Tundra', 'Campo'],
+      answer: 0,
+    },
+    {
+      id: 'q2',
+      x: '55%',
+      y: '60%',
+      prompt: 'Que vegetação predomina na tundra?',
+      options: ['Cactos', 'Musgos e liquens', 'Florestas densas', 'Gramíneas'],
+      answer: 1,
+    },
+    {
+      id: 'q3',
+      x: '75%',
+      y: '30%',
+      prompt: 'Desertos apresentam ____ temperaturas e pouca chuva.',
+      options: ['altas', 'baixas', 'médias', 'constantes'],
+      answer: 0,
+    },
+  ];
+
+  const [currentQ, setCurrentQ] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+  const [finished, setFinished] = useState(false);
+  const { lives, addXp, loseLife, resetGame, completeMod } = useGame();
+  const navigate = useNavigate();
+
+  const handleClose = (correct) => {
+    setShowModal(false);
+    if (correct) {
+      addXp(10);
+    } else {
+      loseLife();
+    }
+    if (!correct && lives - 1 <= 0) return;
+    if (currentQ + 1 < questions.length) {
+      setCurrentQ(currentQ + 1);
+    } else {
+      completeMod(2);
+      setFinished(true);
+    }
+  };
+
+  if (lives <= 0) {
+    return (
+      <div className="end-screen">
+        <h2>Game Over</h2>
+        <button onClick={resetGame}>Reiniciar</button>
+      </div>
+    );
+  }
+
+  if (finished) {
+    return (
+      <div className="end-screen">
+        <h2>Missão Completa!</h2>
+        <button onClick={() => navigate('/modulo3')}>Próxima Missão</button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="scene"
+      style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/floresta.png)` }}
+    >
+      {questions.map((q, i) => (
+        <motion.div
+          key={q.id}
+          className="hotspot"
+          style={{ left: q.x, top: q.y }}
+          onClick={() => {
+            setCurrentQ(i);
+            setShowModal(true);
+          }}
+          whileHover={{ scale: 1.2 }}
+        />
+      ))}
+
+      <QuestionModal
+        visible={showModal}
+        question={questions[currentQ]}
+        onClose={handleClose}
+      />
+    </div>
+  );
 }

--- a/app/src/pages/Module3.js
+++ b/app/src/pages/Module3.js
@@ -1,5 +1,101 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGame } from '../context/GameContext';
+import QuestionModal from '../components/QuestionModal';
+import { motion } from 'framer-motion';
+import '../App.css';
 
 export default function Module3() {
-  return <div>Modulo 3</div>;
+  const questions = [
+    {
+      id: 'q1',
+      x: '30%',
+      y: '35%',
+      prompt: 'Qual órgão bombeia sangue?',
+      options: ['Coração', 'Rim', 'Pulmão', 'Estômago'],
+      answer: 0,
+    },
+    {
+      id: 'q2',
+      x: '55%',
+      y: '60%',
+      prompt: 'Qual órgão filtra o sangue?',
+      options: ['Fígado', 'Pulmão', 'Rim', 'Coração'],
+      answer: 2,
+    },
+    {
+      id: 'q3',
+      x: '75%',
+      y: '45%',
+      prompt: 'Onde ocorre a troca gasosa?',
+      options: ['Estômago', 'Pulmão', 'Coração', 'Pele'],
+      answer: 1,
+    },
+  ];
+
+  const [currentQ, setCurrentQ] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+  const [finished, setFinished] = useState(false);
+  const { lives, addXp, loseLife, resetGame, completeMod } = useGame();
+  const navigate = useNavigate();
+
+  const handleClose = (correct) => {
+    setShowModal(false);
+    if (correct) {
+      addXp(10);
+    } else {
+      loseLife();
+    }
+    if (!correct && lives - 1 <= 0) return;
+    if (currentQ + 1 < questions.length) {
+      setCurrentQ(currentQ + 1);
+    } else {
+      completeMod(3);
+      setFinished(true);
+    }
+  };
+
+  if (lives <= 0) {
+    return (
+      <div className="end-screen">
+        <h2>Game Over</h2>
+        <button onClick={resetGame}>Reiniciar</button>
+      </div>
+    );
+  }
+
+  if (finished) {
+    return (
+      <div className="end-screen">
+        <h2>Missão Completa!</h2>
+        <button onClick={() => navigate('/modulo4')}>Próxima Missão</button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="scene"
+      style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/anatomia.png)` }}
+    >
+      {questions.map((q, i) => (
+        <motion.div
+          key={q.id}
+          className="hotspot"
+          style={{ left: q.x, top: q.y }}
+          onClick={() => {
+            setCurrentQ(i);
+            setShowModal(true);
+          }}
+          whileHover={{ scale: 1.2 }}
+        />
+      ))}
+
+      <QuestionModal
+        visible={showModal}
+        question={questions[currentQ]}
+        onClose={handleClose}
+      />
+    </div>
+  );
 }

--- a/app/src/pages/Module4.js
+++ b/app/src/pages/Module4.js
@@ -1,5 +1,101 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useGame } from '../context/GameContext';
+import QuestionModal from '../components/QuestionModal';
+import { motion } from 'framer-motion';
+import '../App.css';
 
 export default function Module4() {
-  return <div>Modulo 4</div>;
+  const questions = [
+    {
+      id: 'q1',
+      x: '30%',
+      y: '40%',
+      prompt: 'Qual a área de um retângulo de 4x3?',
+      options: ['7', '12', '9', '8'],
+      answer: 1,
+    },
+    {
+      id: 'q2',
+      x: '55%',
+      y: '60%',
+      prompt: 'Qual a área de um círculo de raio 7?',
+      options: ['49π', '14π', '28', '7π'],
+      answer: 0,
+    },
+    {
+      id: 'q3',
+      x: '75%',
+      y: '30%',
+      prompt: 'Perímetro de um triângulo 3,4,5?',
+      options: ['12', '9', '10', '15'],
+      answer: 0,
+    },
+  ];
+
+  const [currentQ, setCurrentQ] = useState(0);
+  const [showModal, setShowModal] = useState(false);
+  const [finished, setFinished] = useState(false);
+  const { lives, addXp, loseLife, resetGame, completeMod } = useGame();
+  const navigate = useNavigate();
+
+  const handleClose = (correct) => {
+    setShowModal(false);
+    if (correct) {
+      addXp(10);
+    } else {
+      loseLife();
+    }
+    if (!correct && lives - 1 <= 0) return;
+    if (currentQ + 1 < questions.length) {
+      setCurrentQ(currentQ + 1);
+    } else {
+      completeMod(4);
+      setFinished(true);
+    }
+  };
+
+  if (lives <= 0) {
+    return (
+      <div className="end-screen">
+        <h2>Game Over</h2>
+        <button onClick={resetGame}>Reiniciar</button>
+      </div>
+    );
+  }
+
+  if (finished) {
+    return (
+      <div className="end-screen">
+        <h2>Missão Completa!</h2>
+        <button onClick={() => navigate('/')}>Voltar ao Início</button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="scene"
+      style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/geometria.png)` }}
+    >
+      {questions.map((q, i) => (
+        <motion.div
+          key={q.id}
+          className="hotspot"
+          style={{ left: q.x, top: q.y }}
+          onClick={() => {
+            setCurrentQ(i);
+            setShowModal(true);
+          }}
+          whileHover={{ scale: 1.2 }}
+        />
+      ))}
+
+      <QuestionModal
+        visible={showModal}
+        question={questions[currentQ]}
+        onClose={handleClose}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add global scene/hotspot/modal styles
- implement QuestionModal component
- wire GameProvider at the app root
- build interactive Module1–4 pages with hotspots and question flow

## Testing
- `npm install`
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_68802738c134832eaa04b836a0cc0aec