### PR TITLE
Apply Style Guide with CSS modules

### DIFF
--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,63 +1,10 @@
 body {
   margin: 0;
-  font-family: "Segoe UI", Tahoma, sans-serif;
+  font-family: 'Segoe UI', Tahoma, sans-serif;
   background-color: #1f1f1f;
   color: #ffffff;
 }
 
-.header {
-  position: fixed;
-  top: 0;
-  width: 100%;
-  padding: 16px;
-  background-color: #2c2c2c;
-  color: #f1c40f;
-  text-align: center;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
-  font-weight: 600;
-}
-
-.layout {
-  padding-top: 72px;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-.content {
-  flex: 1;
-  padding: 16px;
-}
-
-.footernav {
-  display: flex;
-  justify-content: space-around;
-  background-color: #2c2c2c;
-  padding: 16px;
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  box-shadow: 0 -4px 8px rgba(0,0,0,0.3);
-}
-
-.footernav button {
-  background-color: #f1c40f;
-  border: none;
-  border-radius: 8px;
-  padding: 8px 16px;
-  font-weight: 600;
-}
-
-/* Cenário de jogo com imagem de fundo */
-.scene {
-  position: relative;
-  width: 100%;
-  height: calc(100vh - 160px);
-  background-size: cover;
-  background-position: center;
-}
-
-/* Pontos clicáveis */
 .hotspot {
   position: absolute;
   width: 40px;
@@ -67,81 +14,4 @@ body {
   transform: translate(-50%, -50%);
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
-
-/* Modal de pergunta */
-.modal-overlay {
-  position: fixed;
-  inset: 0;
-  background-color: rgba(0, 0, 0, 0.7);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 10;
-}
-
-.modal-content {
-  background-color: #2c2c2c;
-  color: #ffffff;
-  padding: 16px;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  width: 80%;
-  max-width: 320px;
-}
-
-.modal-content h2 {
-  margin-top: 0;
-  font-weight: 600;
-}
-
-.modal-content .options {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-top: 16px;
-}
-
-.modal-content .options button {
-  background-color: #f1c40f;
-  color: #2c2c2c;
-  border: none;
-  border-radius: 8px;
-  padding: 8px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-/* Tela final de vitória ou derrota */
-.end-screen {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: calc(100vh - 160px);
-  gap: 16px;
-}
-
-/* Badge de feedback e vitória */
-.badge {
-  background-color: #f1c40f;
-  color: #2c2c2c;
-  padding: 8px 16px;
-  border-radius: 24px;
-  font-weight: 700;
-  margin-bottom: 8px;
-}
-
-.victory-container {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.confetti {
-  position: absolute;
-  width: 8px;
-  height: 8px;
-  border-radius: 2px;
 }

--- a/app/src/components/ConfettiParticle.js
+++ b/app/src/components/ConfettiParticle.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion } from 'framer-motion';
+import styles from './QuestionModal.module.css';
 
 // Partícula individual de confete usada no badge de vitória
 export default function ConfettiParticle({ x }) {
@@ -7,7 +8,7 @@ export default function ConfettiParticle({ x }) {
   const color = colors[Math.floor(Math.random() * colors.length)];
   return (
     <motion.div
-      className="confetti"
+      className={styles.confetti}
       style={{ left: x, backgroundColor: color }}
       initial={{ opacity: 1, y: 0, rotate: 0 }}
       animate={{ opacity: 0, y: 120, rotate: 360 }}

--- a/app/src/components/FooterNav.js
+++ b/app/src/components/FooterNav.js
@@ -1,17 +1,29 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import '../App.css';
+import styles from './Layout.module.css';
 
 export default function FooterNav() {
   return (
-    <nav className="footernav">
-      <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+    <nav className={styles.footernav}>
+      <motion.button
+        className={styles.btn}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+      >
         Missão
       </motion.button>
-      <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+      <motion.button
+        className={styles.btn}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+      >
         Menu
       </motion.button>
-      <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+      <motion.button
+        className={styles.btn}
+        whileHover={{ scale: 1.05 }}
+        whileTap={{ scale: 0.95 }}
+      >
         Perfil
       </motion.button>
     </nav>

--- a/app/src/components/Header.js
+++ b/app/src/components/Header.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import '../App.css';
+import styles from './Layout.module.css';
 
 export default function Header() {
   return (
-    <header className="header">
+    <header className={styles.header}>
       <h1>Detetives da Aprendizagem</h1>
     </header>
   );

--- a/app/src/components/Layout.js
+++ b/app/src/components/Layout.js
@@ -2,13 +2,13 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import FooterNav from './FooterNav';
-import '../App.css';
+import styles from './Layout.module.css';
 
 export default function Layout() {
   return (
-    <div className="layout">
+    <div className={styles.layout}>
       <Header />
-      <main className="content">
+      <main className={styles.content}>
         <Outlet />
       </main>
       <FooterNav />

--- a/app/src/components/Layout.module.css
+++ b/app/src/components/Layout.module.css
@@ -1,0 +1,63 @@
+:root {
+  --color-primary: #f1c40f;
+  --color-secondary: #2c2c2c;
+  --color-bg: #1f1f1f;
+  --color-text: #ffffff;
+  --color-error: #c0392b;
+  --color-success: #27ae60;
+  --space-unit: 8px;
+}
+
+/* Layout containers */
+.layout {
+  padding-top: calc(var(--space-unit) * 9);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.content {
+  flex: 1;
+  padding: calc(var(--space-unit) * 2);
+}
+
+/* Header styles */
+.header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  padding: calc(var(--space-unit) * 2);
+  background-color: var(--color-secondary);
+  color: var(--color-primary);
+  text-align: center;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  font-weight: 600;
+}
+
+/* Footer navigation */
+.footernav {
+  display: flex;
+  justify-content: space-around;
+  background-color: var(--color-secondary);
+  padding: calc(var(--space-unit) * 2);
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.3);
+}
+
+/* Generic button */
+.btn {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  border: none;
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  font-weight: 600;
+}
+
+.btn:hover {
+  transform: scale(1.05);
+}

--- a/app/src/components/QuestionModal.js
+++ b/app/src/components/QuestionModal.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import ConfettiParticle from './ConfettiParticle';
-import '../App.css';
+import styles from './QuestionModal.module.css';
 
 export default function QuestionModal({ visible, question, onClose }) {
   const [result, setResult] = useState(null); // true = correto, false = incorreto
@@ -28,13 +28,13 @@ export default function QuestionModal({ visible, question, onClose }) {
     <AnimatePresence>
       {visible && (
         <motion.div
-          className="modal-overlay"
+          className={styles.modalOverlay}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
         >
           <motion.div
-            className="modal-content"
+            className={styles.modalContent}
             initial={{ y: -50, opacity: 0 }}
             animate={{
               y: 0,
@@ -47,10 +47,10 @@ export default function QuestionModal({ visible, question, onClose }) {
             transition={{ duration: result === false ? 0.5 : 0.4 }}
           >
             <h2>{question.prompt}</h2>
-            <div className="options">
+            <div className={styles.options}>
               {result === true && (
                 <motion.div
-                  className="badge"
+                  className={styles.badge}
                   initial={{ scale: 0 }}
                   animate={{ scale: [0, 1.2, 1] }}
                   transition={{ duration: 0.6 }}
@@ -62,6 +62,7 @@ export default function QuestionModal({ visible, question, onClose }) {
               {question.options.map((opt, idx) => (
                 <motion.button
                   key={idx}
+                  className={styles.btn}
                   onClick={() => handleClick(idx === question.answer)}
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}

--- a/app/src/components/QuestionModal.module.css
+++ b/app/src/components/QuestionModal.module.css
@@ -1,0 +1,80 @@
+:root {
+  --color-primary: #f1c40f;
+  --color-secondary: #2c2c2c;
+  --color-bg: #1f1f1f;
+  --color-text: #ffffff;
+  --color-error: #c0392b;
+  --color-success: #27ae60;
+  --space-unit: 8px;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.modal-content {
+  background-color: var(--color-secondary);
+  color: var(--color-text);
+  padding: calc(var(--space-unit) * 2);
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  width: 80%;
+  max-width: 320px;
+}
+
+.modal-content h2 {
+  margin-top: 0;
+  font-weight: 600;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-unit);
+  margin-top: calc(var(--space-unit) * 2);
+}
+
+.badge {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
+  border-radius: 24px;
+  font-weight: 700;
+  margin-bottom: var(--space-unit);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.btn {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  border: none;
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  font-weight: 600;
+}
+
+.btn:hover {
+  transform: scale(1.05);
+}
+
+.victory-container {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confetti {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}

--- a/app/src/components/VictoryBadge.js
+++ b/app/src/components/VictoryBadge.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import ConfettiParticle from './ConfettiParticle';
+import styles from './QuestionModal.module.css';
 
 // Badge exibido ao finalizar o módulo com animação e confete
 export default function VictoryBadge() {
@@ -9,9 +10,9 @@ export default function VictoryBadge() {
   ));
 
   return (
-    <div className="victory-container">
+    <div className={styles.victoryContainer}>
       <motion.div
-        className="badge"
+        className={styles.badge}
         initial={{ scale: 0 }}
         animate={{ scale: [0, 1.2, 1] }}
         transition={{ duration: 0.6 }}

--- a/app/src/pages/Home.js
+++ b/app/src/pages/Home.js
@@ -62,7 +62,7 @@ export default function Home() {
             <p className={styles.desc}>{mod.desc}</p>
             {/* Botao que navega para a rota do modulo */}
             <motion.button
-              className={styles.button}
+              className={styles.btn}
               onClick={() => navigate(mod.path)}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}

--- a/app/src/pages/Home.module.css
+++ b/app/src/pages/Home.module.css
@@ -1,7 +1,17 @@
+:root {
+  --color-primary: #f1c40f;
+  --color-secondary: #2c2c2c;
+  --color-bg: #1f1f1f;
+  --color-text: #ffffff;
+  --color-error: #c0392b;
+  --color-success: #27ae60;
+  --space-unit: 8px;
+}
+
 .grid {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 16px;
+  gap: var(--space-unit);
 }
 
 @media (min-width: 600px) {
@@ -11,13 +21,14 @@
 }
 
 .card {
-  background-color: #2c2c2c;
-  color: #ffffff;
+  background-color: var(--color-secondary);
+  color: var(--color-text);
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
+  margin: var(--space-unit);
 }
 
 .image {
@@ -27,7 +38,7 @@
 }
 
 .content {
-  padding: 16px;
+  padding: calc(var(--space-unit) * 2);
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -35,20 +46,26 @@
 
 .title {
   font-weight: 600;
-  margin: 0 0 8px;
+  margin: 0 0 var(--space-unit);
 }
 
 .desc {
-  margin: 0 0 16px;
+  margin: 0 0 calc(var(--space-unit) * 2);
+  font-weight: 400;
 }
 
-.button {
-  background-color: #f1c40f;
-  color: #2c2c2c;
+.btn {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
   border: none;
   border-radius: 8px;
-  padding: 8px 16px;
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
   font-weight: 600;
   cursor: pointer;
   align-self: start;
+  transition: transform 0.2s;
+}
+
+.btn:hover {
+  transform: scale(1.05);
 }

--- a/app/src/pages/Module1.js
+++ b/app/src/pages/Module1.js
@@ -5,7 +5,7 @@ import QuestionModal from '../components/QuestionModal';
 import Hotspot from '../components/Hotspot';
 import VictoryBadge from '../components/VictoryBadge';
 import { motion } from 'framer-motion';
-import '../App.css';
+import styles from './Module1.module.css';
 
 export default function Module1() {
   // Perguntas do módulo com posições dos hotspots
@@ -62,9 +62,10 @@ export default function Module1() {
   // Tela de derrota
   if (lives <= 0) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <h2>Game Over</h2>
         <motion.button
+          className={styles.btn}
           onClick={resetGame}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -78,9 +79,10 @@ export default function Module1() {
   // Tela de vitória
   if (finished) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <VictoryBadge />
         <motion.button
+          className={styles.btn}
           onClick={() => navigate('/modulo2')}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -93,7 +95,7 @@ export default function Module1() {
 
   return (
     <div
-      className="scene"
+      className={styles.scene}
       style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/padaria.png)` }}
     >
       {/* Hotspots que disparam as perguntas */}

--- a/app/src/pages/Module1.module.css
+++ b/app/src/pages/Module1.module.css
@@ -1,0 +1,41 @@
+:root {
+  --color-primary: #f1c40f;
+  --color-secondary: #2c2c2c;
+  --color-bg: #1f1f1f;
+  --color-text: #ffffff;
+  --color-error: #c0392b;
+  --color-success: #27ae60;
+  --space-unit: 8px;
+}
+
+.scene {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 160px);
+  background-size: cover;
+  background-position: center;
+}
+
+.end-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 160px);
+  gap: calc(var(--space-unit) * 2);
+}
+
+.btn {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  border: none;
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  font-weight: 600;
+}
+
+.btn:hover {
+  transform: scale(1.05);
+}

--- a/app/src/pages/Module2.js
+++ b/app/src/pages/Module2.js
@@ -5,7 +5,7 @@ import QuestionModal from '../components/QuestionModal';
 import Hotspot from '../components/Hotspot';
 import VictoryBadge from '../components/VictoryBadge';
 import { motion } from 'framer-motion';
-import '../App.css';
+import styles from './Module2.module.css';
 
 export default function Module2() {
   const questions = [
@@ -59,9 +59,10 @@ export default function Module2() {
 
   if (lives <= 0) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <h2>Game Over</h2>
         <motion.button
+          className={styles.btn}
           onClick={resetGame}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -74,9 +75,10 @@ export default function Module2() {
 
   if (finished) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <VictoryBadge />
         <motion.button
+          className={styles.btn}
           onClick={() => navigate('/modulo3')}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -89,7 +91,7 @@ export default function Module2() {
 
   return (
     <div
-      className="scene"
+      className={styles.scene}
       style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/floresta.png)` }}
     >
       {questions.map((q, i) => (

--- a/app/src/pages/Module2.module.css
+++ b/app/src/pages/Module2.module.css
@@ -1,0 +1,41 @@
+:root {
+  --color-primary: #f1c40f;
+  --color-secondary: #2c2c2c;
+  --color-bg: #1f1f1f;
+  --color-text: #ffffff;
+  --color-error: #c0392b;
+  --color-success: #27ae60;
+  --space-unit: 8px;
+}
+
+.scene {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 160px);
+  background-size: cover;
+  background-position: center;
+}
+
+.end-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 160px);
+  gap: calc(var(--space-unit) * 2);
+}
+
+.btn {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  border: none;
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  font-weight: 600;
+}
+
+.btn:hover {
+  transform: scale(1.05);
+}

--- a/app/src/pages/Module3.js
+++ b/app/src/pages/Module3.js
@@ -5,7 +5,7 @@ import QuestionModal from '../components/QuestionModal';
 import Hotspot from '../components/Hotspot';
 import VictoryBadge from '../components/VictoryBadge';
 import { motion } from 'framer-motion';
-import '../App.css';
+import styles from './Module3.module.css';
 
 export default function Module3() {
   const questions = [
@@ -59,9 +59,10 @@ export default function Module3() {
 
   if (lives <= 0) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <h2>Game Over</h2>
         <motion.button
+          className={styles.btn}
           onClick={resetGame}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -74,9 +75,10 @@ export default function Module3() {
 
   if (finished) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <VictoryBadge />
         <motion.button
+          className={styles.btn}
           onClick={() => navigate('/modulo4')}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -89,7 +91,7 @@ export default function Module3() {
 
   return (
     <div
-      className="scene"
+      className={styles.scene}
       style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/anatomia.png)` }}
     >
       {questions.map((q, i) => (

--- a/app/src/pages/Module3.module.css
+++ b/app/src/pages/Module3.module.css
@@ -1,0 +1,41 @@
+:root {
+  --color-primary: #f1c40f;
+  --color-secondary: #2c2c2c;
+  --color-bg: #1f1f1f;
+  --color-text: #ffffff;
+  --color-error: #c0392b;
+  --color-success: #27ae60;
+  --space-unit: 8px;
+}
+
+.scene {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 160px);
+  background-size: cover;
+  background-position: center;
+}
+
+.end-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 160px);
+  gap: calc(var(--space-unit) * 2);
+}
+
+.btn {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  border: none;
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  font-weight: 600;
+}
+
+.btn:hover {
+  transform: scale(1.05);
+}

--- a/app/src/pages/Module4.js
+++ b/app/src/pages/Module4.js
@@ -5,7 +5,7 @@ import QuestionModal from '../components/QuestionModal';
 import Hotspot from '../components/Hotspot';
 import VictoryBadge from '../components/VictoryBadge';
 import { motion } from 'framer-motion';
-import '../App.css';
+import styles from './Module4.module.css';
 
 export default function Module4() {
   const questions = [
@@ -59,9 +59,10 @@ export default function Module4() {
 
   if (lives <= 0) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <h2>Game Over</h2>
         <motion.button
+          className={styles.btn}
           onClick={resetGame}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -74,9 +75,10 @@ export default function Module4() {
 
   if (finished) {
     return (
-      <div className="end-screen">
+      <div className={styles.endScreen}>
         <VictoryBadge />
         <motion.button
+          className={styles.btn}
           onClick={() => navigate('/')}
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
@@ -89,7 +91,7 @@ export default function Module4() {
 
   return (
     <div
-      className="scene"
+      className={styles.scene}
       style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/scenes/geometria.png)` }}
     >
       {questions.map((q, i) => (

--- a/app/src/pages/Module4.module.css
+++ b/app/src/pages/Module4.module.css
@@ -1,0 +1,41 @@
+:root {
+  --color-primary: #f1c40f;
+  --color-secondary: #2c2c2c;
+  --color-bg: #1f1f1f;
+  --color-text: #ffffff;
+  --color-error: #c0392b;
+  --color-success: #27ae60;
+  --space-unit: 8px;
+}
+
+.scene {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 160px);
+  background-size: cover;
+  background-position: center;
+}
+
+.end-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 160px);
+  gap: calc(var(--space-unit) * 2);
+}
+
+.btn {
+  background-color: var(--color-primary);
+  color: var(--color-secondary);
+  border: none;
+  padding: calc(var(--space-unit) * 1) calc(var(--space-unit) * 2);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s;
+  font-weight: 600;
+}
+
+.btn:hover {
+  transform: scale(1.05);
+}


### PR DESCRIPTION
## Summary
- migrate layout and module pages to CSS modules
- style question modal, victory badge and confetti
- refactor components to use new classes
- clean up global App.css

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68802c4ccb7c832e96c226f95056b937