### PR TITLE
Fix next app path configuration

### DIFF
--- a/Aprender/app/src/pages/index.tsx
+++ b/Aprender/app/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import semestersData from '@/app/data/semesters.json';
+import semestersData from '@/data/semesters.json';
 
 interface Semester {
   id: number;

--- a/Aprender/app/src/pages/semestre/[id]/index.tsx
+++ b/Aprender/app/src/pages/semestre/[id]/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import ModuleCard from '../../../components/ModuleCard';
-import schoolsData from '@/app/data/schools.json';
-import { ModuloAppPEX } from '@/app/models/Module';
+import schoolsData from '@/data/schools.json';
+import { ModuloAppPEX } from '@/models/Module';
 
 const modules: ModuloAppPEX[] = (schoolsData as { modules: ModuloAppPEX[] }).modules;
 

--- a/Aprender/package.json
+++ b/Aprender/package.json
@@ -2,9 +2,9 @@
   "name": "aprender-e-viver",
   "version": "1.0.0",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "dev": "next dev app",
+    "build": "next build app",
+    "start": "next start app",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/Aprender/tsconfig.json
+++ b/Aprender/tsconfig.json
@@ -17,13 +17,13 @@
     "isolatedModules": true,
     "jsx": "preserve",
     // <— ESSENCIAL para o paths funcionar
-    "baseUrl": ".",
+    "baseUrl": "app",
     "paths": {
-      // agora @/ qualquer coisa vai buscar em src/
+      // agora @/ qualquer coisa vai buscar em app/src/
       "@/*": [
         "src/*"
       ],
-      // se quiser algo para assets públicos:
+      // se quiser algo para assets públicos dentro de app/public
       "@public/*": [
         "public/*"
       ]


### PR DESCRIPTION
## Summary
- update Next.js scripts to use `app` directory
- fix tsconfig baseUrl and path aliases
- correct imports referencing `@/app/*`

## Testing
- `npm install` *(fails: registry.npmjs.org blocked)*
- `npm start` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68823baf01a4832e925b94a28c9adece